### PR TITLE
Add CPIX test vectors link to guidelines

### DIFF
--- a/content/guidelines.md
+++ b/content/guidelines.md
@@ -47,7 +47,7 @@ The scope of this document is to define a Content Protection Information Exchang
 
 **Latest Version:**
 
-DASH-IF Implementation Guidelines v2.1: [Content Protection Information Exchange Format (CPIX)](https://dash-industry-forum.github.io/docs/CPIX2.1/HTML/Index.html)| ([PDF](https://dash-industry-forum.github.io/docs/CPIX2.1/PDF/Index.pdf)) | ([XSD](https://dash-industry-forum.github.io/docs/CPIX2.1/XSD/cpix.zip))| ([Bugtracker](https://gitreports.com/issue/Dash-Industry-Forum/CPIX))
+DASH-IF Implementation Guidelines v2.1: [Content Protection Information Exchange Format (CPIX)](https://dash-industry-forum.github.io/docs/CPIX2.1/HTML/Index.html) | ([PDF](https://dash-industry-forum.github.io/docs/CPIX2.1/PDF/Index.pdf)) | ([XSD](https://dash-industry-forum.github.io/docs/CPIX2.1/XSD/cpix.zip)) | ([Bugtracker](https://gitreports.com/issue/Dash-Industry-Forum/CPIX)) | [Test vectors](https://github.com/Dash-Industry-Forum/cpix-test-vectors)
 
 The document provides the following extensions to v2.0:
 

--- a/content/guidelines.md
+++ b/content/guidelines.md
@@ -47,7 +47,7 @@ The scope of this document is to define a Content Protection Information Exchang
 
 **Latest Version:**
 
-DASH-IF Implementation Guidelines v2.1: [Content Protection Information Exchange Format (CPIX)](https://dash-industry-forum.github.io/docs/CPIX2.1/HTML/Index.html) | ([PDF](https://dash-industry-forum.github.io/docs/CPIX2.1/PDF/Index.pdf)) | ([XSD](https://dash-industry-forum.github.io/docs/CPIX2.1/XSD/cpix.zip)) | ([Bugtracker](https://gitreports.com/issue/Dash-Industry-Forum/CPIX)) | [Test vectors](https://github.com/Dash-Industry-Forum/cpix-test-vectors)
+DASH-IF Implementation Guidelines v2.1: [Content Protection Information Exchange Format (CPIX)](https://dash-industry-forum.github.io/docs/CPIX2.1/HTML/Index.html) | ([PDF](https://dash-industry-forum.github.io/docs/CPIX2.1/PDF/Index.pdf)) | ([XSD](https://dash-industry-forum.github.io/docs/CPIX2.1/XSD/cpix.zip)) | ([Bugtracker](https://gitreports.com/issue/Dash-Industry-Forum/CPIX)) | ([Test vectors](https://github.com/Dash-Industry-Forum/cpix-test-vectors))
 
 The document provides the following extensions to v2.0:
 


### PR DESCRIPTION
At some point our examples went missing from this page. This PR restores a link to CPIX examples (aka test vectors).